### PR TITLE
Upgrade to TYPO3 v12/13 compatibility: modernize DI, responses and services

### DIFF
--- a/Classes/Controller/AboController.php
+++ b/Classes/Controller/AboController.php
@@ -13,7 +13,7 @@
 
 namespace FFPI\FfpiNodeUpdates\Controller;
 
-use TYPO3\CMS\Extbase\Mvc\Controller\MvcPropertyMappingConfiguration;
+use Psr\Http\Message\ResponseInterface;
 use FFPI\FfpiNodeUpdates\Domain\Model\Abo;
 use FFPI\FfpiNodeUpdates\Domain\Model\Dto\AboRemoveDemand;
 use FFPI\FfpiNodeUpdates\Domain\Model\Dto\AboNewDemand;
@@ -31,37 +31,13 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class AboController extends ActionController
 {
-    /**
-     * aboRepository
-     *
-     * @var AboRepository
-     *
-     */
-    protected $aboRepository;
+    protected AboRepository $aboRepository;
 
-    /**
-     * nodeRepository
-     *
-     * @var NodeRepository
-     *
-     */
-    protected $nodeRepository;
+    protected NodeRepository $nodeRepository;
 
-    /**
-     * @param AboRepository $aboRepository
-     * @return void
-     */
-    public function injectAboRepository(AboRepository $aboRepository)
+    public function __construct(AboRepository $aboRepository, NodeRepository $nodeRepository)
     {
         $this->aboRepository = $aboRepository;
-    }
-
-    /**
-     * @param NodeRepository $nodeRepository
-     * @return void
-     */
-    public function injectNodeRepository(NodeRepository $nodeRepository)
-    {
         $this->nodeRepository = $nodeRepository;
     }
 
@@ -70,7 +46,7 @@ class AboController extends ActionController
      *
      * @return void
      */
-    public function newAction()
+    public function newAction(): ResponseInterface
     {
         $aboNewDemand = GeneralUtility::makeInstance(AboNewDemand::class);
         $this->view->assign('demand', $aboNewDemand);
@@ -80,6 +56,7 @@ class AboController extends ActionController
                 'nodeId' => QueryInterface::ORDER_ASCENDING
             ]
         )->execute());
+        return $this->htmlResponse();
     }
 
     /**
@@ -89,7 +66,7 @@ class AboController extends ActionController
      * @return void
      * @throws Throwable
      */
-    public function createAction(AboNewDemand $aboNewDemand)
+    public function createAction(AboNewDemand $aboNewDemand): ResponseInterface
     {
         $newAbo = GeneralUtility::makeInstance(Abo::class);
         $newAbo->setEmail($aboNewDemand->getEmail());
@@ -104,6 +81,7 @@ class AboController extends ActionController
 
 
         $this->sendConfirmEmail($newAbo, $secret);
+        return $this->htmlResponse();
     }
 
     /**
@@ -121,12 +99,13 @@ class AboController extends ActionController
      * @return void
      * action removeForm
      */
-    public function removeFormAction(AboRemoveDemand $aboRemoveDemand = null)
+    public function removeFormAction(AboRemoveDemand $aboRemoveDemand = null): ResponseInterface
     {
         if (!($aboRemoveDemand instanceof AboRemoveDemand)) {
             $aboRemoveDemand = new AboRemoveDemand();
         }
         $this->view->assign('aboRemoveDemand', $aboRemoveDemand);
+        return $this->htmlResponse();
     }
 
     /**
@@ -136,7 +115,7 @@ class AboController extends ActionController
      * @return void
      * @throws Throwable
      */
-    public function removeAction(AboRemoveDemand $aboRemoveDemand)
+    public function removeAction(AboRemoveDemand $aboRemoveDemand): ResponseInterface
     {
         $originalAbo = $this->aboRepository->findOneBySecret($aboRemoveDemand->getSecret());
         if (!empty($originalAbo) and $aboRemoveDemand->getEmail() === $originalAbo->getEmail()) {
@@ -146,6 +125,7 @@ class AboController extends ActionController
         } else {
             $this->view->assign('removed', false);
         }
+        return $this->htmlResponse();
     }
 
     /**
@@ -154,7 +134,7 @@ class AboController extends ActionController
      * @return void
      * @throws Throwable
      */
-    public function confirmAction()
+    public function confirmAction(): ResponseInterface
     {
         $args = $this->request->getArguments();
         $secret = $args['secret'];
@@ -176,6 +156,7 @@ class AboController extends ActionController
         } else {
             $this->view->assign('confirmed', false);
         }
+        return $this->htmlResponse();
     }
 
     /**

--- a/Classes/Controller/FreifunkapifileController.php
+++ b/Classes/Controller/FreifunkapifileController.php
@@ -13,6 +13,7 @@
 
 namespace FFPI\FfpiNodeUpdates\Controller;
 
+use Psr\Http\Message\ResponseInterface;
 use FFPI\FfpiNodeUpdates\Domain\Model\FreifunkApiFile;
 use FFPI\FfpiNodeUpdates\Domain\Model\Node;
 use FFPI\FfpiNodeUpdates\Domain\Repository\FreifunkApiFileRepository;
@@ -33,33 +34,21 @@ class FreifunkapifileController extends ActionController
     /** @var string */
     protected $defaultViewObjectName = JsonView::class;
 
-    /** @var FreifunkApiFileRepository */
-    protected $freifunkApiFileRepository;
+    protected FreifunkApiFileRepository $freifunkApiFileRepository;
 
-    /** @var NodeRepository */
-    protected $nodeRepository;
+    protected NodeRepository $nodeRepository;
 
-    /**
-     * @param FreifunkApiFileRepository $freifunkApiFileRepository
-     */
-    public function injectFreifunkApiFileRepository(FreifunkApiFileRepository $freifunkApiFileRepository): void
+    public function __construct(FreifunkApiFileRepository $freifunkApiFileRepository, NodeRepository $nodeRepository)
     {
         $this->freifunkApiFileRepository = $freifunkApiFileRepository;
-    }
-
-    /**
-     * @param NodeRepository $nodeRepository
-     */
-    public function injectNodeRepository(NodeRepository $nodeRepository): void
-    {
         $this->nodeRepository = $nodeRepository;
     }
 
     /**
-     * @return \Psr\Http\Message\ResponseInterface|void
+     * @return ResponseInterface
      * @throws \Exception
      */
-    public function showAction()
+    public function showAction(): ResponseInterface
     {
         /** @var FreifunkApiFile $apiFile */
         $apiFile = $this->freifunkApiFileRepository->findAll()->getFirst();
@@ -70,21 +59,12 @@ class FreifunkapifileController extends ActionController
         $apiFile->setActiveNodes($activeNodeCount);
         $json['value'] = $apiFile->getJson();
         $this->view->assignMultiple($json);
-        if (isset($this->responseFactory) && $this->responseFactory instanceof \Psr\Http\Message\ResponseFactoryInterface) {
-            //TYPO3 11+
-            $ret = $this->responseFactory
-                ->createResponse()
-                ->withHeader('Content-Type', 'application/json')
-                ->withHeader('Access-Control-Allow-Origin', '*')
-                ->withHeader('Cache-Control', 'public, max-age=172800, stale-while-revalidate=345600')
-                ->withBody($this->streamFactory->createStream($this->view->render()));;
-            return $ret;
-        } elseif (isset($this->response)) {
-            //TYPO3 10
-            $this->response->setHeader('Content-Type', 'application/json');
-            $this->response->setHeader('Access-Control-Allow-Origin', '*');
-            $this->response->setHeader('Cache-Control', 'public, max-age=172800, stale-while-revalidate=345600');
-        }
+        return $this->responseFactory
+            ->createResponse()
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Access-Control-Allow-Origin', '*')
+            ->withHeader('Cache-Control', 'public, max-age=172800, stale-while-revalidate=345600')
+            ->withBody($this->streamFactory->createStream($this->view->render()));
 
     }
 

--- a/Classes/Controller/GatewayController.php
+++ b/Classes/Controller/GatewayController.php
@@ -13,30 +13,23 @@
 
 namespace FFPI\FfpiNodeUpdates\Controller;
 
+use Psr\Http\Message\ResponseInterface;
 use FFPI\FfpiNodeUpdates\Domain\Repository\GatewayRepository;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 class GatewayController extends ActionController
 {
-    /**
-     * gatewayRepository
-     *
-     * @var GatewayRepository
-     *
-     */
-    protected $gatewayRepository = null;
+    protected GatewayRepository $gatewayRepository;
 
-    /**
-     * @param GatewayRepository $gatewayRepository
-     */
-    public function injectNodeRepository(GatewayRepository $gatewayRepository): void
+    public function __construct(GatewayRepository $gatewayRepository)
     {
         $this->gatewayRepository = $gatewayRepository;
     }
 
-    public function overviewAction(): void
+    public function overviewAction(): ResponseInterface
     {
         $gateways = $this->gatewayRepository->findAll();
         $this->view->assign('gateways', $gateways);
+        return $this->htmlResponse();
     }
 }

--- a/Classes/Controller/MailController.php
+++ b/Classes/Controller/MailController.php
@@ -13,6 +13,7 @@
 
 namespace FFPI\FfpiNodeUpdates\Controller;
 
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -24,11 +25,13 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  */
 class MailController extends ActionController
 {
-    public function confirmEmailAction(): void
+    public function confirmEmailAction(): ResponseInterface
     {
+        return $this->htmlResponse();
     }
 
-    public function NotificationAction(): void
+    public function notificationAction(): ResponseInterface
     {
+        return $this->htmlResponse();
     }
 }

--- a/Classes/Controller/NodeController.php
+++ b/Classes/Controller/NodeController.php
@@ -2,6 +2,7 @@
 
 namespace FFPI\FfpiNodeUpdates\Controller;
 
+use Psr\Http\Message\ResponseInterface;
 use FFPI\FfpiNodeUpdates\Domain\Model\Node;
 use FFPI\FfpiNodeUpdates\Domain\Repository\NodeRepository;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -22,18 +23,9 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  */
 class NodeController extends ActionController
 {
-    /**
-     * nodeRepository
-     *
-     * @var NodeRepository
-     *
-     */
-    protected $nodeRepository;
+    protected NodeRepository $nodeRepository;
 
-    /**
-     * @param NodeRepository $nodeRepository
-     */
-    public function injectNodeRepository(NodeRepository $nodeRepository): void
+    public function __construct(NodeRepository $nodeRepository)
     {
         $this->nodeRepository = $nodeRepository;
     }
@@ -43,10 +35,11 @@ class NodeController extends ActionController
      *
      * @return void
      */
-    public function listAction(): void
+    public function listAction(): ResponseInterface
     {
         $nodes = $this->nodeRepository->findAll();
         $this->view->assign('nodes', $nodes);
+        return $this->htmlResponse();
     }
 
     /**
@@ -55,8 +48,9 @@ class NodeController extends ActionController
      * @param Node $node
      * @return void
      */
-    public function showAction(Node $node): void
+    public function showAction(Node $node): ResponseInterface
     {
         $this->view->assign('node', $node);
+        return $this->htmlResponse();
     }
 }

--- a/Classes/Task/AbstractNodeTask.php
+++ b/Classes/Task/AbstractNodeTask.php
@@ -5,7 +5,6 @@ namespace FFPI\FfpiNodeUpdates\Task;
 use FFPI\FfpiNodeUpdates\Domain\Model\Node;
 use FFPI\FfpiNodeUpdates\Domain\Repository\NodeRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
@@ -17,11 +16,6 @@ abstract class AbstractNodeTask extends AbstractTask
      * @var NodeRepository
      */
     protected $internalNodeRepository;
-
-    /**
-     * @var ObjectManager
-     */
-    protected $objectManager;
 
     /**
      * @var PersistenceManager
@@ -42,12 +36,11 @@ abstract class AbstractNodeTask extends AbstractTask
 
     protected function initializeTask(): void
     {
-        $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->persistenceManager = $this->objectManager->get(PersistenceManager::class);
-        $this->internalNodeRepository = $this->objectManager->get(NodeRepository::class);
+        $this->persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
+        $this->internalNodeRepository = GeneralUtility::makeInstance(NodeRepository::class);
 
         // Set the correct PID for the storage
-        $querySettings = $this->objectManager->get(Typo3QuerySettings::class);
+        $querySettings = GeneralUtility::makeInstance(Typo3QuerySettings::class);
         $querySettings->setRespectStoragePage(true);
         $querySettings->setRespectSysLanguage(false);
         $querySettings->setStoragePageIds([$this->pid]);

--- a/Classes/Task/GatewayUpdateTask.php
+++ b/Classes/Task/GatewayUpdateTask.php
@@ -9,7 +9,6 @@ use FFPI\FfpiNodeUpdates\Domain\Repository\GatewayRepository;
 use FFPI\FfpiNodeUpdates\Utility\MailUtility;
 use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
@@ -18,9 +17,6 @@ class GatewayUpdateTask extends AbstractTask
 {
     /** @var GatewayRepository */
     protected $gatewayRepository;
-
-    /** @var ObjectManager */
-    protected $objectManager;
 
     /** @var PersistenceManager */
     protected $persistenceManager;
@@ -33,9 +29,8 @@ class GatewayUpdateTask extends AbstractTask
 
     protected function initializeTask(): void
     {
-        $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->gatewayRepository = $this->objectManager->get(GatewayRepository::class);
-        $this->persistenceManager = $this->objectManager->get(PersistenceManager::class);
+        $this->gatewayRepository = GeneralUtility::makeInstance(GatewayRepository::class);
+        $this->persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
         $querySettings = GeneralUtility::makeInstance(Typo3QuerySettings::class);
 
         $querySettings->setStoragePageIds([(int)$this->pid]);

--- a/Classes/Utility/MailUtility.php
+++ b/Classes/Utility/MailUtility.php
@@ -19,17 +19,10 @@ use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\View\StandaloneView;
-use TYPO3\CMS\Frontend\ContentObject\ContentContentObject;
 
 class MailUtility
 {
-
-    /**
-     * @var ObjectManager
-     */
-    var $objectManager;
 
     /**
      * @var ConfigurationManager
@@ -38,8 +31,7 @@ class MailUtility
 
     public function __construct()
     {
-        $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->configurationManager = $this->objectManager->get(ConfigurationManager::class);
+        $this->configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
     }
 
     /**
@@ -89,12 +81,8 @@ class MailUtility
     private function getTemplate(string $template, array $vars): StandaloneView
     {
         /** @var StandaloneView $emailView */
-        $emailView = $this->objectManager->get(StandaloneView::class);
+        $emailView = GeneralUtility::makeInstance(StandaloneView::class);
 
-        $extbaseFrameworkConfiguration = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK, 'ffpi_node_updates', 'tx_ffpinodeupdates_nodeabo');
-
-        $emailView->getRequest()->setControllerExtensionName('ffpi_node_updates');
-        $emailView->getRequest()->setControllerName('mail');
         $view = $this->getTemplatePaths();
         $emailView->setTemplateRootPaths($view['templateRootPaths']);
         $emailView->setPartialRootPaths($view['partialRootPaths']);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,4 +1,22 @@
 services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  FFPI\FfpiNodeUpdates\:
+    resource: '../Classes/*'
+    exclude:
+      - '../Classes/Domain/Model/*'
+
+  FFPI\FfpiNodeUpdates\Controller\:
+    resource: '../Classes/Controller/*'
+    public: true
+
+  FFPI\FfpiNodeUpdates\Task\:
+    resource: '../Classes/Task/*'
+    public: true
+
   FFPI\FfpiNodeUpdates\Property\TypeConverter\AboRemoveDemandConverter:
     tags:
       - name: 'extbase.type_converter'

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ffpi/node-updates",
   "description": "Node Updates",
   "homepage": "https://pinneberg.freifunk.net",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-only",
   "type": "typo3-cms-extension",
   "authors": [
     {
@@ -34,17 +34,22 @@
   "config": {
     "vendor-dir": ".Build/vendor",
     "bin-dir": ".Build/bin",
-    "web-dir": ".Build/web"
+    "web-dir": ".Build/web",
+    "allow-plugins": {
+      "typo3/class-alias-loader": true,
+      "typo3/cms-composer-installers": true
+    }
   },
-  "minimum-stability": "beta",
+  "minimum-stability": "stable",
   "require": {
-    "typo3/cms-core": "10.0.0 - 11.5.99",
-    "typo3/cms-scheduler": "*",
+    "typo3/cms-core": "^12.4 || ^13.4",
+    "typo3/cms-scheduler": "^12.4 || ^13.4",
     "ext-openssl": "*",
     "ext-json": "*",
-    "ext-curl": "*"
-  },
-  "require-dev": {
+    "ext-curl": "*",
+    "typo3/cms-extbase": "^12.4 || ^13.4",
+    "typo3/cms-fluid": "^12.4 || ^13.4",
+    "typo3/cms-frontend": "^12.4 || ^13.4"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.2.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.0.0-11.5.99',
+            'typo3' => '12.4.0-13.4.99',
             'scheduler' => ''
         ],
         'conflicts' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,7 +11,7 @@
  *
  ***/
 
-defined('TYPO3_MODE') || die('Access denied.');
+defined('TYPO3') || die('Access denied.');
 
 call_user_func(
     function ($extKey) {

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') || die('Access denied.');
+defined('TYPO3') || die('Access denied.');
 
 call_user_func(
     function ($extKey) {


### PR DESCRIPTION
### Motivation
- Prepare the extension for TYPO3 12/13 by replacing deprecated APIs and patterns and aligning package metadata and constraints.
- Move to constructor injection and typed properties to use modern dependency injection and improve type safety.
- Standardize HTTP responses to PSR-7 `ResponseInterface` and use proper response factories/streams for JSON and HTML output. 

### Description
- Replaced legacy `inject*` methods with constructor injection and added typed properties across controllers (`AboController`, `NodeController`, `GatewayController`, `FreifunkapifileController`) and adjusted return types to `ResponseInterface` with `return $this->htmlResponse()` where appropriate. 
- Added a `services.yaml` to enable autowiring/autoconfiguration and made controllers and tasks public services, and adjusted Tasks and utilities to use `GeneralUtility::makeInstance()` instead of an `ObjectManager`. 
- Updated JSON response handling in `FreifunkapifileController::showAction` to create a PSR-7 response via `responseFactory`/`streamFactory` and set CORS/cache headers. 
- Refactored `MailUtility` and task initialization to remove `ObjectManager` usage, instantiate required classes with `GeneralUtility::makeInstance()`, and simplified template/view creation. 
- Updated packaging and compatibility metadata: `composer.json` now targets `typo3/cms-core` and related packages `^12.4 || ^13.4`, changes to `license`, `minimum-stability`, and `allow-plugins`, and `ext_emconf.php` TYPO3 constraints updated to `12.4.0-13.4.99`. 
- Replaced legacy `defined('TYPO3_MODE')` guards with `defined('TYPO3')` in `ext_localconf.php` and `ext_tables.php`. 

### Testing
- Ran `composer validate` and `php -l` (PHP lint) across modified files and both checks completed successfully. 
- Verified that the extension service configuration loads without YAML syntax errors using a basic config parse step which succeeded. 
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3da5fa7aa4832d8905852ccd210ace)